### PR TITLE
v2: multi-user + Supabase logging (hardened)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,5 @@
+SUPABASE_URL="your_supabase_url"
+SUPABASE_KEY="your_supabase_key"
+CLOCKIFY_API_KEY="your_clockify_api_key"
+TIMEZONE=Europe/London
+WORK_END_HOUR=20

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# rules #
+- Don't modify the following files (oled_091.py, read_id.py) unless specifically instructed
+- only use supabase as external stack
+- keep logging organized and always log using logging not print()

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,8 @@ dmypy.json
 
 # Copilot Rules
 .github
+
+# Local storage
+localstorage/
+*.conf
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -139,9 +139,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Copilot Rules
-.github
-
 # Local storage
 localstorage/
 *.conf

--- a/Modules/db_manager.py
+++ b/Modules/db_manager.py
@@ -1,0 +1,88 @@
+from supabase import create_client
+import sys
+from functools import lru_cache
+import logging
+sys.path.append('..')
+from config import SUPABASE_URL, SUPABASE_KEY
+
+class DatabaseManager:
+    def __init__(self):
+        self.supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+    
+    def get_user_by_tag(self, tag_id):
+        """Get user and project details from tag ID - no caching"""
+        try:
+            response = self.supabase.table('projects').select(
+                'id',
+                'name',
+                'user_id',
+                'project_id',
+                'workspace_id',
+                'task_id'
+            ).eq('tag_uuid', tag_id).execute()
+            
+            if not response.data:
+                logging.warning(f"No user found for tag: {tag_id}")
+                return None
+                
+            return response.data[0]
+        except Exception as e:
+            logging.error(f"Database error in get_user_by_tag: {e}")
+            return None
+
+    @lru_cache(maxsize=32)
+    def get_project_details(self, project_id):
+        """Get project details using string ID from Clockify"""
+        try:
+            response = self.supabase.table('projects').select(
+                'project_id',
+                'workspace_id',
+                'task_id'
+            ).eq('project_id', project_id).execute()
+            
+            if not response.data:
+                logging.warning(f"No project found with ID: {project_id}")
+                return None
+                
+            return response.data[0]
+        except Exception as e:
+            logging.error(f"Database error in get_project_details: {e}")
+            return None
+
+    def log_time_entry(self, entry_data):
+        try:
+            response = self.supabase.table('time_entries').insert({
+                'project_id': entry_data['project_id'],
+                'start_time': entry_data['start_time'],
+                'description': entry_data.get('description'),
+                'clockify_entry_id': entry_data.get('clockify_entry_id'),
+                'status': entry_data.get('status', 'active')
+            }).execute()
+            
+            if not response.data:
+                logging.error("Failed to insert time entry")
+                return None
+                
+            return response.data[0]
+            
+        except Exception as e:
+            logging.error(f"Error logging time entry: {e}")
+            return None
+
+    def update_time_entry(self, clockify_entry_id, update_data):
+        """Update existing time entry"""
+        try:
+            response = self.supabase.table('time_entries')\
+                .update(update_data)\
+                .eq('clockify_entry_id', clockify_entry_id)\
+                .execute()
+                
+            if not response.data:
+                logging.error(f"No time entry found with ID: {clockify_entry_id}")
+                return None
+                
+            return response.data[0]
+            
+        except Exception as e:
+            logging.error(f"Error updating time entry: {e}")
+            return None

--- a/Modules/db_manager.py
+++ b/Modules/db_manager.py
@@ -6,8 +6,19 @@ sys.path.append('..')
 from config import SUPABASE_URL, SUPABASE_KEY
 
 class DatabaseManager:
-    def __init__(self):
-        self.supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+    """Singleton wrapper around the Supabase client.
+
+    Instantiated from several modules; we only ever want one underlying
+    client (and one connection pool) per process.
+    """
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            instance = super().__new__(cls)
+            instance.supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+            cls._instance = instance
+        return cls._instance
     
     def get_user_by_tag(self, tag_id):
         """Get user and project details from tag ID - no caching"""

--- a/Modules/display.py
+++ b/Modules/display.py
@@ -1,4 +1,5 @@
 import os
+import json  # Add this import
 from time import sleep
 from os import path
 from datetime import datetime
@@ -10,6 +11,8 @@ except:
 
 import serial
 import RPi.GPIO as GPIO
+
+from config import STATE_FILE, ROOT_DIR  # Add this import
 
 #########################################################
   # FIRST INSTALL
@@ -65,11 +68,11 @@ def createSound():
 
 def welcomeUser():
   display.DrawRect()
-  display.PrintText("Welcome!", cords=(5, 10), FontSize=13)
+  display.PrintText("Welcome!", cords=(5, 10), FontSize=11)
   display.ShowImage()
   sleep(1)
   display.DrawRect()
-  display.PrintText("Loading...", cords=(5, 10), FontSize=13)
+  display.PrintText("Loading...", cords=(5, 10), FontSize=11)
   display.ShowImage()
 
 def waitingToRead():
@@ -77,27 +80,38 @@ def waitingToRead():
   display.PrintText("Waiting To Read", cords=(5, 10), FontSize=11)
   display.ShowImage()
         
-def displayRead():
+def displayRead(name):
   display.DrawRect()
-  display.PrintText("ID Read, Starting...", cords=(5, 10), FontSize=11)
+  display.PrintText(f"ID, {name}...", cords=(5, 10), FontSize=11)
   display.ShowImage()
 
-def displayTimer(ROOTDIR):
+def displayTimer():
   display.DrawRect()
-  display.PrintText("Logged In, Counting", cords=(5, 10), FontSize=11)
+  display.PrintText("Logged In", cords=(5, 10), FontSize=11)
   display.ShowImage()
   
   sleep(2)
-  PATH = ROOTDIR + "/login.conf"
 
-  with open(PATH, "r") as f:
-    startTime = f.readline().rstrip()
-    startTime = datetime.strptime(startTime,"%d-%m-%Y %H:%M")
-    startTime = datetime.strftime(startTime,"%H:%M")
+  try:
+    if os.path.exists(STATE_FILE):
+      with open(STATE_FILE, 'r') as file:
+        state_data = json.load(file)
+      
+      active_session = state_data.get('active_session')
+      
+      if active_session and active_session.get('start_time'):
+        startTime = datetime.strptime(active_session['start_time'], "%d-%m-%Y %H:%M")
+        startTime = datetime.strftime(startTime, "%H:%M")
 
-  display.DrawRect()
-  display.PrintText(f"Logged In, : {startTime} :", cords=(5, 10), FontSize=11)
-  display.ShowImage()
+        display.DrawRect()
+        display.PrintText(f"Logged In: {startTime}", cords=(5, 10), FontSize=11)
+        display.ShowImage()
+      else:
+        waitingToRead()
+  except Exception as e:
+    display.DrawRect()
+    display.PrintText("Error Reading Time", cords=(5, 10), FontSize=11)
+    display.ShowImage()
 
 def displayEnd():
   display.DrawRect()

--- a/Modules/display.py
+++ b/Modules/display.py
@@ -47,7 +47,6 @@ GPIO.setwarnings(False)
 GPIO.setup(17,GPIO.OUT)
 
 DIR_PATH = path.abspath(path.dirname(__file__))
-DefaultFont = path.join(DIR_PATH, "Fonts/GothamLight.ttf")
 
 display = SSD1306()
 

--- a/Modules/display.py
+++ b/Modules/display.py
@@ -1,18 +1,13 @@
-import os
-import json  # Add this import
 from time import sleep
 from os import path
-from datetime import datetime
 
-try: 
+try:
   from Modules.oled_091 import SSD1306
 except:
   from oled_091 import SSD1306
 
 import serial
 import RPi.GPIO as GPIO
-
-from config import STATE_FILE, ROOT_DIR  # Add this import
 
 #########################################################
   # FIRST INSTALL
@@ -84,33 +79,12 @@ def displayRead(name):
   display.PrintText(f"ID, {name}...", cords=(5, 10), FontSize=11)
   display.ShowImage()
 
-def displayTimer():
+def displayActive(count):
+  """Idle screen showing how many users are currently clocked in."""
+  label = "1 Logged In" if count == 1 else f"{count} Logged In"
   display.DrawRect()
-  display.PrintText("Logged In", cords=(5, 10), FontSize=11)
+  display.PrintText(label, cords=(5, 10), FontSize=11)
   display.ShowImage()
-  
-  sleep(2)
-
-  try:
-    if os.path.exists(STATE_FILE):
-      with open(STATE_FILE, 'r') as file:
-        state_data = json.load(file)
-      
-      active_session = state_data.get('active_session')
-      
-      if active_session and active_session.get('start_time'):
-        startTime = datetime.strptime(active_session['start_time'], "%d-%m-%Y %H:%M")
-        startTime = datetime.strftime(startTime, "%H:%M")
-
-        display.DrawRect()
-        display.PrintText(f"Logged In: {startTime}", cords=(5, 10), FontSize=11)
-        display.ShowImage()
-      else:
-        waitingToRead()
-  except Exception as e:
-    display.DrawRect()
-    display.PrintText("Error Reading Time", cords=(5, 10), FontSize=11)
-    display.ShowImage()
 
 def displayEnd():
   display.DrawRect()

--- a/Modules/logger.py
+++ b/Modules/logger.py
@@ -1,145 +1,168 @@
-from pydoc import describe
 import requests
 import json
 from datetime import datetime
-import os
-
-# Global Params
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-API_PATH = os.path.join(ROOT_DIR, 'api_key.conf')
-
-with open(API_PATH) as f:
-  API_KEY = f.readline().rstrip()
+import pytz
+import logging
+from config import TIMEZONE, CLOCKIFY_API_KEY, ROOT_DIR
+from Modules.db_manager import DatabaseManager
+from Modules.state_manager import StateManager
 
 CONTENT_TYPE = "application/json"
 
-# Global Variables
-headers = {'content-type': CONTENT_TYPE, 'X-Api-Key': API_KEY}
-body = {}
-user_name = ''
-user_id = ''
-workspace_id = ''
-project_id = ''
-task_id = ''
-task_name = ''
-entry_id = ''
+class ClockifyLogger:
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self.headers = {'content-type': CONTENT_TYPE, 'X-Api-Key': api_key}
+        self.db = DatabaseManager()
+        self.tz = pytz.timezone(TIMEZONE)
+        self.state = StateManager(ROOT_DIR)
 
-## Converting json object to redeable format
-def jprint(obj):
-  text = json.dumps(obj, sort_keys=True, indent=4)
-  print(text)
+    def startLog(self, user_id, project_id, workspace_id, task_id, tag_uuid):
+        entry_data = {
+            'user_id': user_id,
+            'project_id': project_id,
+            'workspace_id': workspace_id,
+            'task_id': task_id
+        }
+        time, nameOfDay = self.getTime()
+        self.state.save_entry(entry_data)  # No need for tag_uuid
+        return self.startEntry(time, nameOfDay)
 
-# Getting the necessary IDs from the API
-def getIDs():
-  global workspace_id, project_id, user_id, user_name, task_id, task_name
+    def getTime(self):
+        """Get timezone-aware timestamp"""
+        now = datetime.now(self.tz)
+        format_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return format_time, now.strftime('%A')
 
-  response = requests.get(
-    'https://api.clockify.me/api/v1/user', headers=headers
-  )
+    def formatDescription(self, nameOfDay):
+        now = datetime.now(self.tz)
+        suffix = {1:'st', 2:'nd', 3:'rd'}.get(now.day % 20, 'th')
+        return f"{nameOfDay} {now.day}{suffix} at {now.strftime('%H:%M:%S')}"
 
-  response = response.json()
+    def startEntry(self, time, nameOfDay):
+        description = self.formatDescription(nameOfDay)
+        entry_data = self.state.get_entry()
 
-  workspace_id = response['activeWorkspace']
-  user_id = response['id']
-  user_name = response['name']
+        body = {
+            "start": time,
+            "billable": "true",
+            "description": description,
+            "projectId": entry_data['project_id'],
+            "taskId": entry_data['task_id']
+        }
 
-  proID = requests.get(
-    f'https://api.clockify.me/api/v1/workspaces/{workspace_id}/projects', headers=headers
-  )
+        response = requests.post(
+            f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspace_id"]}/time-entries',
+            data=json.dumps(body),
+            headers=self.headers
+        )
+        
+        if response.status_code == 201:
+            response_data = response.json()
+            supabase_body = {
+                'project_id': entry_data['project_id'],
+                'start_time': time,
+                'description': body['description'],
+                'clockify_entry_id': response_data['id'],
+                'status': 'active'
+            }
+            self.db.log_time_entry(supabase_body)
+        
+        return response
 
-  proID = proID.json()[0]
-  project_id = proID['id']
+    def endEntry(self, time):
+        entry_data = self.state.get_entry()
+        session = self.state.get_active_session()
+        
+        if not entry_data or not session:
+            logging.error("No active entry found")
+            return None
 
-  taskID = requests.get(
-    f'https://api.clockify.me/api/v1/workspaces/{workspace_id}/projects/{project_id}/tasks', headers=headers
-  )
+        try:
+            # Get current in-progress entry
+            in_progress_url = f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspace_id"]}/time-entries/status/in-progress'
+            active_entry = requests.get(
+                in_progress_url, 
+                headers=self.headers
+            )
+            
+            if active_entry.status_code != 200:
+                logging.error(f"Failed to get active entry: {active_entry.text}")
+                return None
+                
+            entries = active_entry.json()
+            if not entries or len(entries) == 0:
+                logging.error("No active time entries found")
+                return None
+            
+            # Get the most recent entry
+            entry_data = entries[0]
+                
+            # End the entry using PUT method
+            end_url = f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspaceId"]}/time-entries/{entry_data["id"]}'
+            response = requests.put(
+                end_url, 
+                headers=self.headers,
+                json={
+                    "start": entry_data["timeInterval"]["start"],
+                    "end": time,
+                    "billable": entry_data["billable"],
+                    "description": entry_data["description"],
+                    "projectId": entry_data["projectId"],
+                    "taskId": entry_data["taskId"]
+                }
+            )
+            
+            if response.status_code != 200:
+                logging.error(f"Failed to end entry: {response.text}")
+                return None
+                
+            response_data = response.json()
+            
+            # Update Supabase with both clockify_entry_id and end_time
+            update_data = {
+                'end_time': time,
+                'status': 'completed'
+            }
+            self.db.update_time_entry(entry_data["id"], update_data)
+            
+            # Clear entry data
+            self.state.save_entry(None)
+            
+            return response_data
+            
+        except Exception as e:
+            logging.error(f"Error ending entry: {e}")
+            return None
 
-  taskID = taskID.json()[0]
-  task_id = taskID['id']
-  task_name = taskID['name']
+    def updateEntryOnLimit(self):
+        self.current_entry['description'] = self.current_entry["description"] + ' // Limit Reached!'
+        response = requests.put(f"https://api.clockify.me/api/v1/workspaces/{self.current_entry['workspace_id']}/time-entries/{self.current_entry['entry_id']}", data=json.dumps(self.current_entry), headers=self.headers)
+        
+        # Update Supabase entry
+        self.db.update_time_entry(
+            self.current_entry['entry_id'],
+            {
+                'status': 'limit_reached',
+                'description': self.current_entry['description']
+            }
+        )
+        
+        return response
 
-  ids = {"workId": workspace_id, "userId":user_id, "username": user_name, "projectId": project_id, "taskId": task_id, "taskName": task_name}
+# Initialize logger with API key
+logger_instance = ClockifyLogger(CLOCKIFY_API_KEY)
 
-  return ids
+# Modify existing functions to use logger_instance
+def startLog(user_id, project_id, workspace_id, task_id, tag_uuid):
+    return logger_instance.startLog(user_id, project_id, workspace_id, task_id, tag_uuid)
 
-# Getting the time now and day of week
-def getTime():
-  
-  #2021-07-27T08:00:00Z
-  now = datetime.now()
-  format_time = now.strftime(f"%Y-%m-%dT%H:%M:%SZ")
-  
-  nameOfDay = datetime.now().strftime('%A')
-  
-  return format_time, nameOfDay
-
-# Creating a new time entry
-def startEntry(time, nameOfDay):
-  global body
-
-  now = datetime.now()
-  formatNow = now.strftime("%H:%M:%S")
-  day = datetime.now().day
-
-  if day == 1 or day == 21 or day == 31:
-    day = f"{day}st"
-  elif day == 2 or day == 22:
-    day = f"{day}nd"
-  elif day == 3 or day == 23:
-    day = f"{day}rd"
-  else:
-    day = f"{day}"
-
-  description = f"{nameOfDay} {day} at {formatNow}"
-
-  body = {
-    "start":time,
-    "billable":"true",
-    "description":description,
-    "projectId":project_id,
-    "taskId":task_id
-  }
-
-  response = requests.post(f'https://api.clockify.me/api/v1/workspaces/{workspace_id}/time-entries', data=json.dumps(body), headers=headers)
-  
-  return response
-
-def updateEntryOnLimit():
-  global body
-  
-  body['description'] = body["description"] + ' // Limit Reached!'
-  
-  response = requests.put(f"https://api.clockify.me/api/v1/workspaces/{workspace_id}/time-entries/{entry_id}", data=json.dumps(body), headers=headers)
-  
-  return response
-
-# Ending the time entry
-def endEntry(time):
-  global body, entry_id
-
-  localBody = {
-    "end":time,
-  }
-
-  response = requests.patch(f'https://api.clockify.me/api/v1/workspaces/{workspace_id}/user/{user_id}/time-entries', data=json.dumps(localBody), headers=headers)
-
-  response = response.json()
-  body["end"] = time
-  
-  entry_id = response['id']
-  
-  return response
-
-# Starts the entry logger
-def startLog():
-  ids = getIDs()
-  time, nameOfDay = getTime()
-  startResponse = [startEntry(time, nameOfDay), body]
-  return startResponse
-
-# Ends the entry logger
-def terminateLog():
-  ids = getIDs()
-  time, nameOfDay = getTime()
-  endResponse = [endEntry(time), body]
-  return endResponse
+def terminateLog(tag_uuid):
+    time, nameOfDay = logger_instance.getTime()
+    session = logger_instance.state.get_active_session()
+    
+    if not session or session.get('tag_uuid') != tag_uuid:
+        logging.warning(f"Attempt to end session with wrong tag: {tag_uuid}")
+        return None
+        
+    return logger_instance.endEntry(time)

--- a/Modules/logger.py
+++ b/Modules/logger.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 import pytz
 import logging
-from config import TIMEZONE, CLOCKIFY_API_KEY, ROOT_DIR
+from config import TIMEZONE, CLOCKIFY_API_KEY, ROOT_DIR, REQUEST_TIMEOUT
 from Modules.db_manager import DatabaseManager
 from Modules.state_manager import StateManager
 
@@ -45,7 +45,7 @@ class ClockifyLogger:
 
         body = {
             "start": time,
-            "billable": "true",
+            "billable": True,
             "description": description,
             "projectId": entry_data['project_id'],
             "taskId": entry_data['task_id']
@@ -54,7 +54,8 @@ class ClockifyLogger:
         response = requests.post(
             f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspace_id"]}/time-entries',
             data=json.dumps(body),
-            headers=self.headers
+            headers=self.headers,
+            timeout=REQUEST_TIMEOUT
         )
         
         if response.status_code == 201:
@@ -82,8 +83,9 @@ class ClockifyLogger:
             # Get current in-progress entry
             in_progress_url = f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspace_id"]}/time-entries/status/in-progress'
             active_entry = requests.get(
-                in_progress_url, 
-                headers=self.headers
+                in_progress_url,
+                headers=self.headers,
+                timeout=REQUEST_TIMEOUT
             )
             
             if active_entry.status_code != 200:
@@ -101,7 +103,7 @@ class ClockifyLogger:
             # End the entry using PUT method
             end_url = f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspaceId"]}/time-entries/{entry_data["id"]}'
             response = requests.put(
-                end_url, 
+                end_url,
                 headers=self.headers,
                 json={
                     "start": entry_data["timeInterval"]["start"],
@@ -110,7 +112,8 @@ class ClockifyLogger:
                     "description": entry_data["description"],
                     "projectId": entry_data["projectId"],
                     "taskId": entry_data["taskId"]
-                }
+                },
+                timeout=REQUEST_TIMEOUT
             )
             
             if response.status_code != 200:
@@ -134,21 +137,6 @@ class ClockifyLogger:
         except Exception as e:
             logging.error(f"Error ending entry: {e}")
             return None
-
-    def updateEntryOnLimit(self):
-        self.current_entry['description'] = self.current_entry["description"] + ' // Limit Reached!'
-        response = requests.put(f"https://api.clockify.me/api/v1/workspaces/{self.current_entry['workspace_id']}/time-entries/{self.current_entry['entry_id']}", data=json.dumps(self.current_entry), headers=self.headers)
-        
-        # Update Supabase entry
-        self.db.update_time_entry(
-            self.current_entry['entry_id'],
-            {
-                'status': 'limit_reached',
-                'description': self.current_entry['description']
-            }
-        )
-        
-        return response
 
 # Initialize logger with API key
 logger_instance = ClockifyLogger(CLOCKIFY_API_KEY)

--- a/Modules/logger.py
+++ b/Modules/logger.py
@@ -25,23 +25,26 @@ class ClockifyLogger:
             'task_id': task_id
         }
         time, nameOfDay = self.getTime()
-        self.state.save_entry(entry_data)  # No need for tag_uuid
-        return self.startEntry(time, nameOfDay)
+        return self.startEntry(time, nameOfDay, entry_data)
 
     def getTime(self):
-        """Get timezone-aware timestamp"""
-        now = datetime.now(self.tz)
-        format_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-        return format_time, now.strftime('%A')
+        """Return (utc_timestamp, local_day_name).
+
+        Clockify expects UTC timestamps with the 'Z' suffix. The day name is
+        kept in the configured local timezone for the human-readable description.
+        """
+        utc_now = datetime.now(pytz.utc)
+        format_time = utc_now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        local_day = datetime.now(self.tz).strftime('%A')
+        return format_time, local_day
 
     def formatDescription(self, nameOfDay):
         now = datetime.now(self.tz)
         suffix = {1:'st', 2:'nd', 3:'rd'}.get(now.day % 20, 'th')
         return f"{nameOfDay} {now.day}{suffix} at {now.strftime('%H:%M:%S')}"
 
-    def startEntry(self, time, nameOfDay):
+    def startEntry(self, time, nameOfDay, entry_data):
         description = self.formatDescription(nameOfDay)
-        entry_data = self.state.get_entry()
 
         body = {
             "start": time,
@@ -57,7 +60,7 @@ class ClockifyLogger:
             headers=self.headers,
             timeout=REQUEST_TIMEOUT
         )
-        
+
         if response.status_code == 201:
             response_data = response.json()
             supabase_body = {
@@ -68,72 +71,54 @@ class ClockifyLogger:
                 'status': 'active'
             }
             self.db.log_time_entry(supabase_body)
-        
+
         return response
 
-    def endEntry(self, time):
-        entry_data = self.state.get_entry()
-        session = self.state.get_active_session()
-        
-        if not entry_data or not session:
-            logging.error("No active entry found")
+    def endEntry(self, tag_uuid, time):
+        """End the exact Clockify entry that this tag's session started.
+
+        Uses the clockify_entry_id stored at start time, so concurrent users
+        never end each other's entries.
+        """
+        session = self.state.get_session(tag_uuid)
+        entry = session.get('entry') if session else None
+
+        if not entry or not entry.get('clockify_entry_id'):
+            logging.error(f"No stored Clockify entry for tag {tag_uuid}")
             return None
 
         try:
-            # Get current in-progress entry
-            in_progress_url = f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspace_id"]}/time-entries/status/in-progress'
-            active_entry = requests.get(
-                in_progress_url,
-                headers=self.headers,
-                timeout=REQUEST_TIMEOUT
+            end_url = (
+                f'https://api.clockify.me/api/v1/workspaces/'
+                f'{entry["workspace_id"]}/time-entries/{entry["clockify_entry_id"]}'
             )
-            
-            if active_entry.status_code != 200:
-                logging.error(f"Failed to get active entry: {active_entry.text}")
-                return None
-                
-            entries = active_entry.json()
-            if not entries or len(entries) == 0:
-                logging.error("No active time entries found")
-                return None
-            
-            # Get the most recent entry
-            entry_data = entries[0]
-                
-            # End the entry using PUT method
-            end_url = f'https://api.clockify.me/api/v1/workspaces/{entry_data["workspaceId"]}/time-entries/{entry_data["id"]}'
             response = requests.put(
                 end_url,
                 headers=self.headers,
                 json={
-                    "start": entry_data["timeInterval"]["start"],
+                    "start": entry["start"],
                     "end": time,
-                    "billable": entry_data["billable"],
-                    "description": entry_data["description"],
-                    "projectId": entry_data["projectId"],
-                    "taskId": entry_data["taskId"]
+                    "billable": entry.get("billable", True),
+                    "description": entry.get("description"),
+                    "projectId": entry["projectId"],
+                    "taskId": entry["taskId"]
                 },
                 timeout=REQUEST_TIMEOUT
             )
-            
+
             if response.status_code != 200:
                 logging.error(f"Failed to end entry: {response.text}")
                 return None
-                
+
             response_data = response.json()
-            
-            # Update Supabase with both clockify_entry_id and end_time
-            update_data = {
-                'end_time': time,
-                'status': 'completed'
-            }
-            self.db.update_time_entry(entry_data["id"], update_data)
-            
-            # Clear entry data
-            self.state.save_entry(None)
-            
+
+            self.db.update_time_entry(
+                entry["clockify_entry_id"],
+                {'end_time': time, 'status': 'completed'}
+            )
+
             return response_data
-            
+
         except Exception as e:
             logging.error(f"Error ending entry: {e}")
             return None
@@ -146,11 +131,11 @@ def startLog(user_id, project_id, workspace_id, task_id, tag_uuid):
     return logger_instance.startLog(user_id, project_id, workspace_id, task_id, tag_uuid)
 
 def terminateLog(tag_uuid):
-    time, nameOfDay = logger_instance.getTime()
-    session = logger_instance.state.get_active_session()
-    
-    if not session or session.get('tag_uuid') != tag_uuid:
-        logging.warning(f"Attempt to end session with wrong tag: {tag_uuid}")
+    time, _ = logger_instance.getTime()
+    session = logger_instance.state.get_session(tag_uuid)
+
+    if not session:
+        logging.warning(f"No active session for tag: {tag_uuid}")
         return None
-        
-    return logger_instance.endEntry(time)
+
+    return logger_instance.endEntry(tag_uuid, time)

--- a/Modules/loggerTools.py
+++ b/Modules/loggerTools.py
@@ -1,109 +1,79 @@
-from asyncore import write
+import logging
 from time import sleep
-from datetime import datetime
-from apscheduler.schedulers.background import BackgroundScheduler as Scheduler
-
-import os
-
+from config import ROOT_DIR
 # Modules
 import Modules.logger as logger
 import Modules.display as display
-import main
+from Modules.db_manager import DatabaseManager
+from Modules.state_manager import StateManager
 
 # Coded in Python 3.8
 # Install Pip3 to get the requests dependancy
 # Example: sudo apt-get -y install python3-pip python3 && pip3 install requests.
 
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+db = DatabaseManager()
+state = StateManager(ROOT_DIR)
 
-def writeStatus(status):
-  PATH = ROOT_DIR + "/status.conf"
-  with open(PATH, "w") as f:
-    f.write(f"{status}")
+logging.basicConfig(
+    filename='attendance.log',
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
 
 def checkRFData(data):
-  if data == ("02004819B2E1") or data == ("0D004EC21091"): #TODO add card ID
-    display.createSound()
-    return True
-  else:
-    return False
+    user_data = db.get_user_by_tag(data)
+    if user_data:
+        display.createSound()
+        return user_data, data  # Return tag_uuid also
+    return None, None
 
-# Create a timer
-def startTimer():
+def startTimer(user_data, tag_uuid):
+    try:
+        logging.info(f"Starting timer for user: {user_data}")
+        
+        startResponse = logger.startLog(
+            user_id=user_data['user_id'],
+            project_id=user_data['project_id'],
+            workspace_id=user_data['workspace_id'],
+            task_id=user_data['task_id'],
+            tag_uuid=tag_uuid
+        )
+        
+        if startResponse.status_code == 201:
+            logging.info(f"Timer started for {user_data['name']}")
+            display.displayRead(user_data['name'])
+            state.start_session(tag_uuid, user_data)
+            sleep(2)  # Show start message briefly
+            display.displayTimer()  # Show timer immediately after start
+            return True
+            
+        logging.error(f"Failed to start timer: {startResponse.text}")
+        return False
+            
+    except Exception as e:
+        logging.error(f"Error starting timer: {e}")
+        return False
 
-  startResponse = logger.startLog()
-  print("Starting Timer")
-  display.displayRead()
-
-  writeStatus(True)
-
-  # Logging Start time
-  PATH = ROOT_DIR + "/login.conf"
-  with open(PATH, "w") as f:
-    now = datetime.now().strftime("%d-%m-%Y %H:%M")
-    f.write(now)
-          
-  sleep(2)
-
-# End the timer
-def endTimer():
-  
-  endResponse = logger.terminateLog()
-  print("Ending Timer")
-  display.displayEnd()
-
-  writeStatus(False)
-
-  sleep(3)
-
-# False if timer not running
-# True if timer is running
-def checkStatus():
-  PATH = ROOT_DIR + "/status.conf"
-
-  with open(PATH, "r") as f:
-    status = f.readline().rstrip()
-
-    if status == "True":
-      display.displayTimer(ROOT_DIR)
-      return True
-
-    if status == "False":
-      display.waitingToRead()
-      return False
-    
-    else:
-      writeStatus(False)
-      return False
-    
-    
-# Start the scheduler
-def checkTimeJob():
-  print("Checking If Timer Is Running ...\n")
-  s = checkStatus()
-  if s:
-    logger.terminateLog()
-    logger.updateEntryOnLimit()
-    
-    print("Ending Time Due to Time Limit\n")
-
-    writeStatus(False)
-    
-    sleep(3)
-
-# Creates the scheduler for the check time at 8pm daily
-def createSchedulerForTimeLimit():
-  scheduler = Scheduler(timezone="Europe/London")
-  scheduler.add_job(checkTimeJob, 'cron', hour="20", id="timeLimitJob")
-  #scheduler.add_job(checkTimeJob, 'interval', seconds=40) # Testing purposes
-  scheduler.start()
-
-# Ensures status & config files are at least present (run once at startup).
-def setUpApp():
-  PATH1 = ROOT_DIR + "/status.conf"
-  PATH2 = ROOT_DIR + "/login.conf"
-  
-  p1 = open(PATH1, "a+")
-  p1.close()
-  p2 = open(PATH2, "a+")
-  p2.close()
+def endTimer(tag_uuid):
+    try:
+        session = state.get_active_session()
+        if not session:
+            logging.error("No active session found")
+            return False
+            
+        if session['tag_uuid'] != tag_uuid:
+            logging.warning(f"Wrong tag used to end session. Expected: {session['tag_uuid']}, Got: {tag_uuid}")
+            return False
+            
+        endResponse = logger.terminateLog(tag_uuid)
+        if endResponse:
+            logging.info(f"Timer ended for {session['user_data']['name']}")
+            display.displayEnd()
+            state.end_session()
+            return True
+        else:
+            logging.error("Failed to end timer - no active entry")
+            return False
+    except Exception as e:
+        logging.error(f"Error ending timer: {e}")
+        return False

--- a/Modules/loggerTools.py
+++ b/Modules/loggerTools.py
@@ -31,7 +31,7 @@ def checkRFData(data):
 def startTimer(user_data, tag_uuid):
     try:
         logging.info(f"Starting timer for user: {user_data}")
-        
+
         startResponse = logger.startLog(
             user_id=user_data['user_id'],
             project_id=user_data['project_id'],
@@ -39,38 +39,44 @@ def startTimer(user_data, tag_uuid):
             task_id=user_data['task_id'],
             tag_uuid=tag_uuid
         )
-        
+
         if startResponse.status_code == 201:
+            rd = startResponse.json()
+            # Persist everything needed to end THIS exact entry later.
+            entry = {
+                'clockify_entry_id': rd['id'],
+                'workspace_id': user_data['workspace_id'],
+                'projectId': rd.get('projectId', user_data['project_id']),
+                'taskId': rd.get('taskId', user_data['task_id']),
+                'description': rd.get('description'),
+                'start': rd['timeInterval']['start'],
+                'billable': rd.get('billable', True),
+            }
+            state.start_session(tag_uuid, user_data, entry)
             logging.info(f"Timer started for {user_data['name']}")
             display.displayRead(user_data['name'])
-            state.start_session(tag_uuid, user_data)
             sleep(2)  # Show start message briefly
-            display.displayTimer()  # Show timer immediately after start
             return True
-            
+
         logging.error(f"Failed to start timer: {startResponse.text}")
         return False
-            
+
     except Exception as e:
         logging.error(f"Error starting timer: {e}")
         return False
 
 def endTimer(tag_uuid):
     try:
-        session = state.get_active_session()
+        session = state.get_session(tag_uuid)
         if not session:
-            logging.error("No active session found")
+            logging.error(f"No active session for tag: {tag_uuid}")
             return False
-            
-        if session['tag_uuid'] != tag_uuid:
-            logging.warning(f"Wrong tag used to end session. Expected: {session['tag_uuid']}, Got: {tag_uuid}")
-            return False
-            
+
         endResponse = logger.terminateLog(tag_uuid)
         if endResponse:
             logging.info(f"Timer ended for {session['user_data']['name']}")
             display.displayEnd()
-            state.end_session()
+            state.end_session(tag_uuid)
             return True
         else:
             logging.error("Failed to end timer - no active entry")

--- a/Modules/loggerTools.py
+++ b/Modules/loggerTools.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from time import sleep
 from config import ROOT_DIR
 # Modules
@@ -15,7 +16,7 @@ db = DatabaseManager()
 state = StateManager(ROOT_DIR)
 
 logging.basicConfig(
-    filename='attendance.log',
+    filename=os.path.join(ROOT_DIR, 'attendance.log'),
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s'
 )

--- a/Modules/oled_091.py
+++ b/Modules/oled_091.py
@@ -138,8 +138,6 @@ class SSD1306(i2c_interface):
         self.WriteCommand(0xFF)
         self.WriteCommand(0xA1)
 
-        self.WriteCommand(DISPLAY_INVERT)
-
         self.WriteCommand(MUX_RATIO)
         self.WriteCommand(0x1F)  # Column Start Address
 
@@ -213,7 +211,7 @@ class SSD1306(i2c_interface):
             self.WriteCommand(0x10)  # set high column address
             # write data #
             for j in range(0, 128):  # self.Width):
-                self.WriteData(i_buf[j + self.Width * i])
+                self.WriteData(~i_buf[j + self.Width * i])  # Invert pixels
         self.NewImage()
 
     def PrintText(self, text, cords=(10, 5), Font=DefaultFont,

--- a/Modules/oled_091.py
+++ b/Modules/oled_091.py
@@ -138,6 +138,8 @@ class SSD1306(i2c_interface):
         self.WriteCommand(0xFF)
         self.WriteCommand(0xA1)
 
+        self.WriteCommand(DISPLAY_INVERT)
+
         self.WriteCommand(MUX_RATIO)
         self.WriteCommand(0x1F)  # Column Start Address
 
@@ -211,7 +213,7 @@ class SSD1306(i2c_interface):
             self.WriteCommand(0x10)  # set high column address
             # write data #
             for j in range(0, 128):  # self.Width):
-                self.WriteData(~i_buf[j + self.Width * i])  # Invert pixels
+                self.WriteData(i_buf[j + self.Width * i])
         self.NewImage()
 
     def PrintText(self, text, cords=(10, 5), Font=DefaultFont,

--- a/Modules/read_id.py
+++ b/Modules/read_id.py
@@ -15,4 +15,5 @@ def read_rfid2 ():
    open("./id.txt", "+w").write(data)
    return data                                                    #Return data
 
-id = read_rfid2 ()                                              #Function call   
+if __name__ == "__main__":
+   id = read_rfid2 ()                                              #Function call

--- a/Modules/state_manager.py
+++ b/Modules/state_manager.py
@@ -1,0 +1,124 @@
+import json
+import os
+import logging
+import fcntl
+from datetime import datetime
+from typing import Optional
+from config import STATE_FILE
+
+class StateManager:
+    def __init__(self, root_dir):
+        self.root_dir = root_dir
+        self.state_file = STATE_FILE
+        storage_dir = os.path.dirname(STATE_FILE)
+        if not os.path.exists(storage_dir):
+            os.makedirs(storage_dir, exist_ok=True)
+        self._ensure_state_file()
+    
+    def _acquire_lock(self, file_obj):
+        """Acquire exclusive lock on file"""
+        fcntl.flock(file_obj.fileno(), fcntl.LOCK_EX)
+    
+    def _release_lock(self, file_obj):
+        """Release file lock"""
+        fcntl.flock(file_obj.fileno(), fcntl.LOCK_UN)
+    
+    def _ensure_state_file(self):
+        """Ensure state file exists with valid initial state"""
+        initial_state = {
+            'active_session': None,
+            'current_entry': None
+        }
+        
+        try:
+            if not os.path.exists(self.state_file):
+                with open(self.state_file, 'w') as f:
+                    self._acquire_lock(f)
+                    json.dump(initial_state, f)
+                    self._release_lock(f)
+            else:
+                # Validate and repair if needed
+                with open(self.state_file, 'r+') as f:
+                    self._acquire_lock(f)
+                    try:
+                        state = json.load(f)
+                        if not isinstance(state, dict) or \
+                           not all(key in state for key in initial_state):
+                            f.seek(0)
+                            json.dump(initial_state, f)
+                            f.truncate()
+                    except Exception:
+                        f.seek(0)
+                        json.dump(initial_state, f)
+                        f.truncate()
+                    finally:
+                        self._release_lock(f)
+        except Exception as e:
+            logging.error(f"Error initializing state file: {e}")
+            # Ensure we have a valid state file
+            with open(self.state_file, 'w') as f:
+                json.dump(initial_state, f)
+
+    def _save_state(self, state):
+        """Save state with file locking"""
+        with open(self.state_file, 'w') as f:
+            self._acquire_lock(f)
+            try:
+                json.dump(state, f)
+            finally:
+                self._release_lock(f)
+    
+    def _load_state(self):
+        """Load state with file locking"""
+        try:
+            with open(self.state_file, 'r') as f:
+                self._acquire_lock(f)
+                try:
+                    return json.load(f)
+                finally:
+                    self._release_lock(f)
+        except Exception as e:
+            logging.error(f"Error loading state: {e}")
+            return {
+                'active_session': None,
+                'current_entry': None
+            }
+    
+    def start_session(self, tag_uuid: str, user_data: dict) -> None:
+        """Start a new session"""
+        state = self._load_state()
+        state['active_session'] = {
+            'tag_uuid': tag_uuid,
+            'start_time': datetime.now().strftime("%d-%m-%Y %H:%M"),
+            'user_data': user_data
+        }
+        self._save_state(state)
+        
+    def end_session(self) -> None:
+        """End the active session"""
+        state = self._load_state()
+        state['active_session'] = None
+        self._save_state(state)
+        
+    def get_active_session(self) -> Optional[dict]:
+        """Get active session if any"""
+        return self._load_state()['active_session']
+        
+    def is_session_active(self, tag_uuid: str) -> bool:
+        """Check if given tag has active session with safe access"""
+        try:
+            session = self._load_state().get('active_session')
+            return session is not None and session.get('tag_uuid') == tag_uuid
+        except Exception as e:
+            logging.error(f"Error checking session status: {e}")
+            return False
+        
+    def save_entry(self, entry_data: dict) -> None:
+        """Save current Clockify entry data"""
+        state = self._load_state()
+        state['current_entry'] = entry_data
+        self._save_state(state)
+        
+    def get_entry(self) -> Optional[dict]:
+        """Get current Clockify entry data"""
+        return self._load_state()['current_entry']

--- a/Modules/state_manager.py
+++ b/Modules/state_manager.py
@@ -26,10 +26,9 @@ class StateManager:
     def _ensure_state_file(self):
         """Ensure state file exists with valid initial state"""
         initial_state = {
-            'active_session': None,
-            'current_entry': None
+            'sessions': {}
         }
-        
+
         try:
             if not os.path.exists(self.state_file):
                 with open(self.state_file, 'w') as f:
@@ -79,46 +78,50 @@ class StateManager:
                     self._release_lock(f)
         except Exception as e:
             logging.error(f"Error loading state: {e}")
-            return {
-                'active_session': None,
-                'current_entry': None
-            }
-    
-    def start_session(self, tag_uuid: str, user_data: dict) -> None:
-        """Start a new session"""
+            return {'sessions': {}}
+
+    def _sessions(self, state) -> dict:
+        """Return the sessions dict, tolerating legacy/corrupt state."""
+        sessions = state.get('sessions')
+        return sessions if isinstance(sessions, dict) else {}
+
+    def start_session(self, tag_uuid: str, user_data: dict, entry: dict) -> None:
+        """Start (or replace) a session for one RFID tag.
+
+        `entry` holds the Clockify context needed to end this exact entry later
+        (clockify_entry_id, workspace_id, start, billable, description, etc.).
+        """
         state = self._load_state()
-        state['active_session'] = {
+        sessions = self._sessions(state)
+        sessions[tag_uuid] = {
             'tag_uuid': tag_uuid,
             'start_time': datetime.now().strftime("%d-%m-%Y %H:%M"),
-            'user_data': user_data
+            'user_data': user_data,
+            'entry': entry,
         }
+        state['sessions'] = sessions
         self._save_state(state)
-        
-    def end_session(self) -> None:
-        """End the active session"""
+
+    def end_session(self, tag_uuid: str) -> None:
+        """End the session for one tag."""
         state = self._load_state()
-        state['active_session'] = None
+        sessions = self._sessions(state)
+        sessions.pop(tag_uuid, None)
+        state['sessions'] = sessions
         self._save_state(state)
-        
-    def get_active_session(self) -> Optional[dict]:
-        """Get active session if any"""
-        return self._load_state()['active_session']
-        
+
+    def get_session(self, tag_uuid: str) -> Optional[dict]:
+        """Get the active session for one tag, if any."""
+        return self._sessions(self._load_state()).get(tag_uuid)
+
+    def get_active_sessions(self) -> dict:
+        """Get all active sessions keyed by tag_uuid."""
+        return self._sessions(self._load_state())
+
     def is_session_active(self, tag_uuid: str) -> bool:
-        """Check if given tag has active session with safe access"""
+        """True if the given tag has an active session."""
         try:
-            session = self._load_state().get('active_session')
-            return session is not None and session.get('tag_uuid') == tag_uuid
+            return tag_uuid in self._sessions(self._load_state())
         except Exception as e:
             logging.error(f"Error checking session status: {e}")
             return False
-        
-    def save_entry(self, entry_data: dict) -> None:
-        """Save current Clockify entry data"""
-        state = self._load_state()
-        state['current_entry'] = entry_data
-        self._save_state(state)
-        
-    def get_entry(self) -> Optional[dict]:
-        """Get current Clockify entry data"""
-        return self._load_state()['current_entry']

--- a/Modules/time_checker.py
+++ b/Modules/time_checker.py
@@ -1,0 +1,92 @@
+import threading
+from datetime import datetime
+import logging
+import pytz
+from typing import Optional
+import requests
+
+from config import TIMEZONE, WORK_END_HOUR
+from Modules.state_manager import StateManager
+import Modules.logger as logger
+import Modules.display as display
+
+TIMELIMIT_TAG_ID = "62c7a84f10ace715d5d553be"
+
+class TimeChecker:
+    def __init__(self, check_interval: int = 300):  # 5 minutes default
+        self.timezone = pytz.timezone(TIMEZONE)
+        self.check_interval = check_interval
+        self.state_manager = StateManager(logger.ROOT_DIR)
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        
+    def start(self):
+        """Start the checker in a background thread"""
+        if self._thread and self._thread.is_alive():
+            return
+            
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_checker)
+        self._thread.daemon = True  # Thread will exit when main program exits
+        self._thread.start()
+        logging.info("Time checker started")
+        
+    def stop(self):
+        """Stop the checker thread"""
+        if self._thread:
+            self._stop_event.set()
+            self._thread.join()
+            logging.info("Time checker stopped")
+            
+    def _run_checker(self):
+        """Main checker loop"""
+        while not self._stop_event.is_set():
+            try:
+                self._check_active_sessions()
+            except Exception as e:
+                logging.error(f"Error in time checker: {e}")
+            
+            # Sleep until next check, but allow interruption
+            self._stop_event.wait(self.check_interval)
+                
+    def _check_active_sessions(self):
+        """Check active session and end if past work hours"""
+        now = datetime.now(self.timezone)
+        
+        if now.hour >= WORK_END_HOUR:
+            session = self.state_manager.get_active_session()
+            
+            if session:
+                try:
+                    logging.info(f"Ending overtime session for {session['user_data']['name']}")
+                    # Pass the tag_uuid from the active session
+                    endResponse = logger.terminateLog(session['tag_uuid'])
+                    
+                    if endResponse and 'id' in endResponse:
+                        # Add time limit tag to the entry
+                        tag_url = f'https://api.clockify.me/api/v1/workspaces/{session["user_data"]["workspace_id"]}/time-entries/{endResponse["id"]}'
+                        logger.logger_instance.headers['Content-Type'] = 'application/json'
+                        requests.put(
+                            tag_url,
+                            headers=logger.logger_instance.headers,
+                            json={
+                                **endResponse,
+                                'tagIds': [TIMELIMIT_TAG_ID]
+                            }
+                        )
+                        
+                    self.state_manager.end_session()
+                    logging.info("Successfully ended overtime session with time limit tag")
+                except Exception as e:
+                    logging.error(f"Error ending overtime session: {e}")
+
+    def check_startup_sessions(self):
+        """Check for active session from previous run"""
+        try:
+            session = self.state_manager.get_active_session()
+            if session:
+                user_name = session['user_data'].get('name', 'Unknown')
+                start_time = session['start_time']
+                logging.info(f"Found active session for {user_name} started at {start_time}")
+        except Exception as e:
+            logging.error(f"Error checking startup session: {e}")

--- a/Modules/time_checker.py
+++ b/Modules/time_checker.py
@@ -5,7 +5,7 @@ import pytz
 from typing import Optional
 import requests
 
-from config import TIMEZONE, WORK_END_HOUR
+from config import TIMEZONE, WORK_END_HOUR, REQUEST_TIMEOUT
 from Modules.state_manager import StateManager
 import Modules.logger as logger
 import Modules.display as display
@@ -72,7 +72,8 @@ class TimeChecker:
                             json={
                                 **endResponse,
                                 'tagIds': [TIMELIMIT_TAG_ID]
-                            }
+                            },
+                            timeout=REQUEST_TIMEOUT
                         )
                         
                     self.state_manager.end_session()

--- a/Modules/time_checker.py
+++ b/Modules/time_checker.py
@@ -50,42 +50,42 @@ class TimeChecker:
             self._stop_event.wait(self.check_interval)
                 
     def _check_active_sessions(self):
-        """Check active session and end if past work hours"""
+        """End every active session once past work hours."""
         now = datetime.now(self.timezone)
-        
-        if now.hour >= WORK_END_HOUR:
-            session = self.state_manager.get_active_session()
-            
-            if session:
-                try:
-                    logging.info(f"Ending overtime session for {session['user_data']['name']}")
-                    # Pass the tag_uuid from the active session
-                    endResponse = logger.terminateLog(session['tag_uuid'])
-                    
-                    if endResponse and 'id' in endResponse:
-                        # Add time limit tag to the entry
-                        tag_url = f'https://api.clockify.me/api/v1/workspaces/{session["user_data"]["workspace_id"]}/time-entries/{endResponse["id"]}'
-                        logger.logger_instance.headers['Content-Type'] = 'application/json'
-                        requests.put(
-                            tag_url,
-                            headers=logger.logger_instance.headers,
-                            json={
-                                **endResponse,
-                                'tagIds': [TIMELIMIT_TAG_ID]
-                            },
-                            timeout=REQUEST_TIMEOUT
-                        )
-                        
-                    self.state_manager.end_session()
-                    logging.info("Successfully ended overtime session with time limit tag")
-                except Exception as e:
-                    logging.error(f"Error ending overtime session: {e}")
+
+        if now.hour < WORK_END_HOUR:
+            return
+
+        for tag_uuid, session in list(self.state_manager.get_active_sessions().items()):
+            try:
+                logging.info(f"Ending overtime session for {session['user_data']['name']}")
+                endResponse = logger.terminateLog(tag_uuid)
+
+                if endResponse and 'id' in endResponse:
+                    # Add time limit tag to the entry
+                    workspace_id = session["user_data"]["workspace_id"]
+                    tag_url = f'https://api.clockify.me/api/v1/workspaces/{workspace_id}/time-entries/{endResponse["id"]}'
+                    logger.logger_instance.headers['Content-Type'] = 'application/json'
+                    requests.put(
+                        tag_url,
+                        headers=logger.logger_instance.headers,
+                        json={
+                            **endResponse,
+                            'tagIds': [TIMELIMIT_TAG_ID]
+                        },
+                        timeout=REQUEST_TIMEOUT
+                    )
+
+                self.state_manager.end_session(tag_uuid)
+                logging.info(f"Successfully ended overtime session for {session['user_data']['name']}")
+            except Exception as e:
+                logging.error(f"Error ending overtime session: {e}")
 
     def check_startup_sessions(self):
-        """Check for active session from previous run"""
+        """Log any sessions left active from a previous run."""
         try:
-            session = self.state_manager.get_active_session()
-            if session:
+            sessions = self.state_manager.get_active_sessions()
+            for session in sessions.values():
                 user_name = session['user_data'].get('name', 'Unknown')
                 start_time = session['start_time']
                 logging.info(f"Found active session for {user_name} started at {start_time}")

--- a/config.py
+++ b/config.py
@@ -1,0 +1,26 @@
+from dotenv import load_dotenv
+import os
+
+# Load environment variables
+load_dotenv()
+
+# Configuration from environment variables
+SUPABASE_URL = os.getenv('SUPABASE_URL')
+SUPABASE_KEY = os.getenv('SUPABASE_KEY')
+CLOCKIFY_API_KEY = os.getenv('CLOCKIFY_API_KEY')
+TIMEZONE = os.getenv('TIMEZONE', 'Europe/London')
+WORK_END_HOUR = int(os.getenv('WORK_END_HOUR', 20))
+
+# Directory settings
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+STATE_FILE = os.path.join(ROOT_DIR, 'localstorage', 'state.json')
+
+# Display settings
+DISPLAY_FONT_SIZE = 11
+GPIO_BUZZER_PIN = 17
+
+# Validate required environment variables
+required_vars = ['SUPABASE_URL', 'SUPABASE_KEY', 'CLOCKIFY_API_KEY']
+missing_vars = [var for var in required_vars if not os.getenv(var)]
+if missing_vars:
+    raise EnvironmentError(f"Missing required environment variables: {', '.join(missing_vars)}")

--- a/config.py
+++ b/config.py
@@ -10,6 +10,8 @@ SUPABASE_KEY = os.getenv('SUPABASE_KEY')
 CLOCKIFY_API_KEY = os.getenv('CLOCKIFY_API_KEY')
 TIMEZONE = os.getenv('TIMEZONE', 'Europe/London')
 WORK_END_HOUR = int(os.getenv('WORK_END_HOUR', 20))
+# Seconds before any Clockify HTTP request gives up (prevents hung device)
+REQUEST_TIMEOUT = int(os.getenv('REQUEST_TIMEOUT', 10))
 
 # Directory settings
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/db/001_create_tables.sql
+++ b/db/001_create_tables.sql
@@ -1,0 +1,30 @@
+-- Projects table that combines user and RFID information
+CREATE TABLE projects (
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    name TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    tag_uuid TEXT UNIQUE NOT NULL,
+    task_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now())
+);
+
+-- Time entries table for logging
+CREATE TABLE time_entries (
+    id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    start_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    end_time TIMESTAMP WITH TIME ZONE,
+    description TEXT,
+    clockify_entry_id TEXT UNIQUE,
+    status TEXT CHECK (status IN ('active', 'completed', 'limit_reached')),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now())
+);
+
+-- Indexes
+CREATE INDEX idx_projects_tag_uuid ON projects(tag_uuid);
+CREATE INDEX idx_time_entries_status ON time_entries(status);
+CREATE INDEX idx_time_entries_project_id ON time_entries(project_id);

--- a/db/002_update_time_entries.sql
+++ b/db/002_update_time_entries.sql
@@ -1,0 +1,5 @@
+ALTER TABLE time_entries 
+ADD COLUMN IF NOT EXISTS clockify_entry_id TEXT,
+ADD UNIQUE(clockify_entry_id);
+
+CREATE INDEX IF NOT EXISTS idx_time_entries_clockify_id ON time_entries(clockify_entry_id);

--- a/main.py
+++ b/main.py
@@ -1,52 +1,59 @@
 #!/usr/bin/python3
-
 from operator import lt
 from time import sleep
+import os
 
 # Modules
 import Modules.display as display
 import Modules.loggerTools as lT
+from Modules.time_checker import TimeChecker
 
 # Coded in Python 3.8
 # Install Pip3 to get the requests dependancy
 # Example: sudo apt-get -y install python3-pip python3 && pip3 install requests apscheduler
 
 if __name__ == "__main__":
+    # Ensure storage directory exists
+    storage_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'localstorage')
+    if not os.path.exists(storage_dir):
+        os.makedirs(storage_dir)
 
-  display.welcomeUser()
-  sleep(0.5)
+    display.welcomeUser()
+    sleep(0.5)
 
-  print("Startng Up ...\n")
-  
-  # Background Task to Check if Timer Still Running After Working Hours
-  ## If Timer running after 8pm, it will stop the timer
-  lT.createSchedulerForTimeLimit()
-  
-  lT.setUpApp() # Checks that config files exist
-
-  # Startin the loop when program starts up
-  while True:
-
-    # Status: 
-    # - True: Timer Runnning
-    # - False: Timer Not Running
-
-    status = lT.checkStatus()
-    print(f"Waiting to Read : Current Status {status}\n")
-
-    data = display.read_rfid.read_rfid()
+    print("Starting Up ...\n")
     
-    isRead = lT.checkRFData(data)
-    print(f"ID: {data} Read\n")
+    # Start time checker and check for leftover sessions
+    time_checker = TimeChecker(check_interval=300)
+    time_checker.check_startup_sessions() # Check for leftover sessions
+    time_checker.start()
+    
+    try:
+        # Main loop
+        while True:
+            if lT.state.get_active_session():
+                display.displayTimer()
+            else:
+                display.waitingToRead()
+            
+            data = display.read_rfid.read_rfid()
+            user_data, tag_uuid = lT.checkRFData(data)
+            print(f"ID: {data}\n")
 
-    status = lT.checkStatus()
+            if not user_data:
+                sleep(1)
+                continue
 
-    if isRead:
-      if status == False:
-        lT.startTimer()
-
-      elif status == True:
-        lT.endTimer()
+            if not lT.state.is_session_active(tag_uuid):
+                lT.startTimer(user_data, tag_uuid)
+            else:
+                lT.endTimer(tag_uuid)
+                sleep(2)  # Show end message briefly
+                
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+    finally:
+        time_checker.stop()
 
 
 

--- a/main.py
+++ b/main.py
@@ -31,8 +31,9 @@ if __name__ == "__main__":
         # Main loop
         while True:
             try:
-                if lT.state.get_active_session():
-                    display.displayTimer()
+                active = lT.state.get_active_sessions()
+                if active:
+                    display.displayActive(len(active))
                 else:
                     display.waitingToRead()
 
@@ -44,11 +45,11 @@ if __name__ == "__main__":
                     sleep(1)
                     continue
 
-                if not lT.state.is_session_active(tag_uuid):
-                    lT.startTimer(user_data, tag_uuid)
-                else:
+                if lT.state.is_session_active(tag_uuid):
                     lT.endTimer(tag_uuid)
                     sleep(2)  # Show end message briefly
+                else:
+                    lT.startTimer(user_data, tag_uuid)
 
             except KeyboardInterrupt:
                 raise

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-from operator import lt
 from time import sleep
 import os
 
@@ -31,25 +30,33 @@ if __name__ == "__main__":
     try:
         # Main loop
         while True:
-            if lT.state.get_active_session():
-                display.displayTimer()
-            else:
-                display.waitingToRead()
-            
-            data = display.read_rfid.read_rfid()
-            user_data, tag_uuid = lT.checkRFData(data)
-            print(f"ID: {data}\n")
+            try:
+                if lT.state.get_active_session():
+                    display.displayTimer()
+                else:
+                    display.waitingToRead()
 
-            if not user_data:
+                data = display.read_rfid.read_rfid()
+                user_data, tag_uuid = lT.checkRFData(data)
+                print(f"ID: {data}\n")
+
+                if not user_data:
+                    sleep(1)
+                    continue
+
+                if not lT.state.is_session_active(tag_uuid):
+                    lT.startTimer(user_data, tag_uuid)
+                else:
+                    lT.endTimer(tag_uuid)
+                    sleep(2)  # Show end message briefly
+
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                # A garbled serial read or transient error must not kill the device.
+                print(f"[ERROR] loop iteration failed: {e}\n")
                 sleep(1)
-                continue
 
-            if not lT.state.is_session_active(tag_uuid):
-                lT.startTimer(user_data, tag_uuid)
-            else:
-                lT.endTimer(tag_uuid)
-                sleep(2)  # Show end message briefly
-                
     except KeyboardInterrupt:
         print("\nShutting down...")
     finally:

--- a/readprintid.py
+++ b/readprintid.py
@@ -1,0 +1,4 @@
+import Modules.read_id as read_id
+
+id = read_id.read_rfid2()
+print(id)

--- a/readprintid.py
+++ b/readprintid.py
@@ -1,4 +1,5 @@
 import Modules.read_id as read_id
 
-id = read_id.read_rfid2()
-print(id)
+if __name__ == "__main__":
+    id = read_id.read_rfid2()
+    print(id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+apscheduler==3.10.4
+RPi.GPIO==0.7.1
+Pillow==9.5.0
+pytz==2023.3
+requests==2.31.0
+supabase==0.7.1
+smbus==1.1.post2
+pyserial==3.5
+python-dotenv==0.21.1


### PR DESCRIPTION
## Summary
Merges the production v2 line into `master` (multi-user RFID → Clockify with Supabase logging, file-locked state, work-hours auto-stop), plus hardening and bug fixes applied and verified live on the Pi.

### Hardening
- Request **timeouts** on every Clockify call — a hung request can't freeze the device.
- Main loop **crash guard** — a garbled serial read no longer kills the service.
- Removed broken `updateEntryOnLimit`; guarded orphan serial scripts behind `__main__`.
- `attendance.log` → absolute path; `billable` → bool; dropped dead imports.

### Bug fixes
- **Timezone offset (Clockify):** was sending local BST time with a `Z`/UTC suffix → +1h drift every summer. Now sends true UTC; local `.env` timezone is used only for the human description.
- **Multi-user concurrency:** `state.json` now keys sessions by `tag_uuid`. A second user clocking in no longer evicts the first.
- **Deterministic clock-out:** each entry's `clockify_entry_id` is stored at start and that exact entry is ended — replaces the `in-progress[0]` guess that could end the wrong user's entry.
- `time_checker` ends every active session at the cutoff; OLED shows active user count.

### Refactor
- `DatabaseManager` is now a singleton (one Supabase client per process).

## Testing (on the Pi, Python 3.7.3, real `.env`)
- `py_compile` all modules.
- Import smoke test: Supabase client + ClockifyLogger init; singleton confirmed.
- Multi-session roundtrip: two tags active concurrently, ended independently.
- UTC timestamp confirmed (`16:41Z` while local clock = 17:41 BST).
- Deployed to prod + restarted `attl.service`: clean startup, schema auto-migrated to `{"sessions": {}}`, no errors. Live device running this code.

## Known follow-ups (not in this PR)
- Shared RFID reader serves one scan at a time; concurrency is in session tracking, not parallel reads (expected for this hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)