### PR TITLE
Ops hardening: self-healing service, log rotation, reject beep, state tests

### DIFF
--- a/Modules/display.py
+++ b/Modules/display.py
@@ -54,11 +54,19 @@ class read_rfid():
     data=data.decode("utf-8")
     return data
 
-#Plays read sound
+#Plays read sound (accepted card)
 def createSound():
   GPIO.output(17,GPIO.HIGH)
   sleep(.2)
   GPIO.output(17,GPIO.LOW)
+
+#Plays reject sound (unknown card): two short beeps
+def createRejectSound():
+  for _ in range(2):
+    GPIO.output(17, GPIO.HIGH)
+    sleep(.05)
+    GPIO.output(17, GPIO.LOW)
+    sleep(.05)
 
 def welcomeUser():
   display.DrawRect()

--- a/Modules/loggerTools.py
+++ b/Modules/loggerTools.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from logging.handlers import RotatingFileHandler
 from time import sleep
 from config import ROOT_DIR
 # Modules
@@ -15,11 +16,19 @@ from Modules.state_manager import StateManager
 db = DatabaseManager()
 state = StateManager(ROOT_DIR)
 
-logging.basicConfig(
-    filename=os.path.join(ROOT_DIR, 'attendance.log'),
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
+# Rotate the log so it can't grow without bound (1 MB x 3 backups).
+# Attach explicitly rather than via basicConfig: imported libraries (supabase
+# /httpx) may configure the root logger first, which makes basicConfig a no-op.
+_log_handler = RotatingFileHandler(
+    os.path.join(ROOT_DIR, 'attendance.log'),
+    maxBytes=1_000_000,
+    backupCount=3,
 )
+_log_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+_root_logger = logging.getLogger()
+_root_logger.setLevel(logging.INFO)
+if not any(isinstance(h, RotatingFileHandler) for h in _root_logger.handlers):
+    _root_logger.addHandler(_log_handler)
 
 def checkRFData(data):
     user_data = db.get_user_by_tag(data)

--- a/Modules/state_manager.py
+++ b/Modules/state_manager.py
@@ -7,11 +7,12 @@ from typing import Optional
 from config import STATE_FILE
 
 class StateManager:
-    def __init__(self, root_dir):
+    def __init__(self, root_dir=None, state_file=None):
+        # `state_file` is injectable for tests; defaults to the configured path.
         self.root_dir = root_dir
-        self.state_file = STATE_FILE
-        storage_dir = os.path.dirname(STATE_FILE)
-        if not os.path.exists(storage_dir):
+        self.state_file = state_file or STATE_FILE
+        storage_dir = os.path.dirname(self.state_file)
+        if storage_dir and not os.path.exists(storage_dir):
             os.makedirs(storage_dir, exist_ok=True)
         self._ensure_state_file()
     

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,25 @@
+# Deployment
+
+The Pi runs `main.py` under systemd as `attl.service`.
+
+## Install / update the service unit
+
+```bash
+sudo cp deploy/attl.service /etc/systemd/system/attl.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now attl.service
+```
+
+`/etc/systemd/system/` overrides any vendor copy in `/lib/systemd/system/`.
+
+`Restart=always` means the service self-heals: if `main.py` crashes or exits,
+systemd restarts it after `RestartSec`.
+
+## Deploy code
+
+```bash
+cd ~/Attendance_Logger
+git pull --ff-only origin master
+sudo systemctl restart attl.service
+journalctl -u attl.service -f   # expect "Time checker started"
+```

--- a/deploy/attl.service
+++ b/deploy/attl.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Attendance Logger Service
+# Needs the network for Clockify + Supabase at startup.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/pi/Attendance_Logger
+ExecStart=/usr/bin/python3 /home/pi/Attendance_Logger/main.py
+# Self-heal: restart on any exit (crash, error, or clean stop), not just abort.
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/main.py
+++ b/main.py
@@ -42,6 +42,8 @@ if __name__ == "__main__":
                 print(f"ID: {data}\n")
 
                 if not user_data:
+                    if data and data.strip():
+                        display.createRejectSound()  # unknown card
                     sleep(1)
                     continue
 

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,92 @@
+"""Unit tests for StateManager (hardware-free core).
+
+Run from the repo root:
+    python3 -m unittest discover -s tests
+"""
+import json
+import os
+import tempfile
+import unittest
+
+# config.py validates these at import time; provide dummies so importing
+# StateManager doesn't require a real .env.
+os.environ.setdefault('SUPABASE_URL', 'http://localhost')
+os.environ.setdefault('SUPABASE_KEY', 'dummy')
+os.environ.setdefault('CLOCKIFY_API_KEY', 'dummy')
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Modules.state_manager import StateManager
+
+
+def make_entry(eid):
+    return {
+        'clockify_entry_id': eid,
+        'workspace_id': 'w',
+        'projectId': 'p',
+        'taskId': 't',
+        'description': 'd',
+        'start': '2026-06-09T10:00:00Z',
+        'billable': True,
+    }
+
+
+class StateManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+        self.tmp.close()
+        self.path = self.tmp.name
+        os.remove(self.path)  # let StateManager create it fresh
+        self.sm = StateManager(state_file=self.path)
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_starts_empty(self):
+        self.assertEqual(self.sm.get_active_sessions(), {})
+
+    def test_start_and_get(self):
+        self.sm.start_session('tagA', {'name': 'A', 'workspace_id': 'w'}, make_entry('e1'))
+        self.assertTrue(self.sm.is_session_active('tagA'))
+        s = self.sm.get_session('tagA')
+        self.assertEqual(s['user_data']['name'], 'A')
+        self.assertEqual(s['entry']['clockify_entry_id'], 'e1')
+
+    def test_concurrent_sessions(self):
+        self.sm.start_session('tagA', {'name': 'A', 'workspace_id': 'w'}, make_entry('e1'))
+        self.sm.start_session('tagB', {'name': 'B', 'workspace_id': 'w'}, make_entry('e2'))
+        self.assertEqual(set(self.sm.get_active_sessions()), {'tagA', 'tagB'})
+        # Ending one must not touch the other.
+        self.sm.end_session('tagA')
+        self.assertFalse(self.sm.is_session_active('tagA'))
+        self.assertTrue(self.sm.is_session_active('tagB'))
+        self.assertEqual(self.sm.get_session('tagB')['entry']['clockify_entry_id'], 'e2')
+
+    def test_end_unknown_tag_is_noop(self):
+        self.sm.start_session('tagA', {'name': 'A', 'workspace_id': 'w'}, make_entry('e1'))
+        self.sm.end_session('ghost')
+        self.assertTrue(self.sm.is_session_active('tagA'))
+
+    def test_persists_across_instances(self):
+        self.sm.start_session('tagA', {'name': 'A', 'workspace_id': 'w'}, make_entry('e1'))
+        other = StateManager(state_file=self.path)
+        self.assertTrue(other.is_session_active('tagA'))
+
+    def test_legacy_schema_migrates(self):
+        # Old v2 schema without the 'sessions' key.
+        with open(self.path, 'w') as f:
+            json.dump({'active_session': None, 'current_entry': None}, f)
+        sm = StateManager(state_file=self.path)
+        self.assertEqual(sm.get_active_sessions(), {})
+
+    def test_corrupt_file_recovers(self):
+        with open(self.path, 'w') as f:
+            f.write('}{ not json')
+        sm = StateManager(state_file=self.path)
+        self.assertEqual(sm.get_active_sessions(), {})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Reliability/quality improvements on top of the v2 merge.

- **Self-healing service** — `deploy/attl.service` switches `Restart=on-abort` → `Restart=always` (+ `RestartSec=5`, `network-online` ordering, `WorkingDirectory`). The old policy only restarted on signal-abort, so any crash/error exit left the device silently dead. Install steps in `deploy/README.md`.
- **Working log rotation** — `RotatingFileHandler` (1 MB × 3) attached explicitly to the root logger. `basicConfig` was a no-op because imported libraries (supabase/httpx) configure logging first, so `attendance.log` never actually rotated or wrote.
- **Reject beep** — distinct double-beep on an unknown card (was silent).
- **Tests** — `StateManager` takes an injectable `state_file`; `tests/test_state_manager.py` (stdlib `unittest`) covers start/end, concurrent tags, no-op end, persistence, legacy migration, corrupt-file recovery. **7/7 green on the Pi (Python 3.7).**

## Deliberately skipped
- Auto-retry on Clockify `start` (POST is non-idempotent → duplicate-entry risk).
- Run-as-`pi` (file-ownership churn for little gain).

## Testing
- `py_compile` all modules + test file.
- `python3 -m unittest discover -s tests` → 7 passed on the Pi.
- Service restart policy / log file verified on the device post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)