### PR TITLE
Startup reconciliation: Clockify as source of truth

### DIFF
--- a/Modules/db_manager.py
+++ b/Modules/db_manager.py
@@ -41,6 +41,23 @@ class DatabaseManager:
             logging.error(f"Database error in get_user_by_tag: {e}")
             return None
 
+    def get_all_projects(self):
+        """All project rows (tag -> person mapping) for startup reconciliation."""
+        try:
+            response = self.supabase.table('projects').select(
+                'id',
+                'name',
+                'user_id',
+                'tag_uuid',
+                'project_id',
+                'workspace_id',
+                'task_id'
+            ).execute()
+            return response.data or []
+        except Exception as e:
+            logging.error(f"Database error in get_all_projects: {e}")
+            return []
+
     @lru_cache(maxsize=32)
     def get_project_details(self, project_id):
         """Get project details using string ID from Clockify"""

--- a/Modules/logger.py
+++ b/Modules/logger.py
@@ -74,6 +74,19 @@ class ClockifyLogger:
 
         return response
 
+    def get_in_progress(self, workspace_id):
+        """Return Clockify's currently in-progress entries for a workspace."""
+        url = f'https://api.clockify.me/api/v1/workspaces/{workspace_id}/time-entries/status/in-progress'
+        try:
+            resp = requests.get(url, headers=self.headers, timeout=REQUEST_TIMEOUT)
+            if resp.status_code != 200:
+                logging.error(f"Failed to fetch in-progress entries: {resp.text}")
+                return []
+            return resp.json() or []
+        except Exception as e:
+            logging.error(f"Error fetching in-progress entries: {e}")
+            return []
+
     def endEntry(self, tag_uuid, time):
         """End the exact Clockify entry that this tag's session started.
 

--- a/Modules/reconcile.py
+++ b/Modules/reconcile.py
@@ -1,0 +1,70 @@
+"""Pure reconciliation logic between Clockify (source of truth) and local state.
+
+No hardware, config, or network imports — kept pure so it is unit-testable in
+isolation. The caller fetches the inputs (Supabase projects, Clockify
+in-progress entries, current local sessions) and applies the returned actions.
+"""
+
+
+def reconcile_sessions(projects, in_progress_entries, active_sessions):
+    """Compute how to bring local sessions in line with Clockify.
+
+    Args:
+        projects: list of Supabase project rows. Each maps a tag to a person:
+            {tag_uuid, name, user_id, project_id, workspace_id, task_id}.
+        in_progress_entries: list of Clockify in-progress time entries (the
+            shape Clockify returns: id, projectId, taskId, workspaceId,
+            description, billable, timeInterval.start).
+        active_sessions: current local sessions keyed by tag_uuid.
+
+    Returns:
+        (to_add, to_remove)
+        to_add: {tag_uuid: (user_data, entry)} sessions to create — Clockify
+            entries that have no matching local session (e.g. lost to a crash,
+            or a timer that was running across a restart).
+        to_remove: [tag_uuid] sessions to drop — local sessions whose Clockify
+            entry is no longer in progress (ended elsewhere).
+    """
+    by_project = {}
+    for p in projects:
+        # First project row wins if a project_id somehow repeats.
+        by_project.setdefault(p['project_id'], p)
+
+    live_entry_ids = set()
+    to_add = {}
+
+    for e in in_progress_entries:
+        live_entry_ids.add(e['id'])
+        proj = by_project.get(e.get('projectId'))
+        if not proj:
+            # Running entry we can't map back to a tag; leave it alone.
+            continue
+        tag = proj['tag_uuid']
+        if tag in active_sessions:
+            continue  # already tracked locally
+
+        user_data = {
+            'name': proj['name'],
+            'user_id': proj['user_id'],
+            'project_id': proj['project_id'],
+            'workspace_id': proj['workspace_id'],
+            'task_id': proj['task_id'],
+        }
+        entry = {
+            'clockify_entry_id': e['id'],
+            'workspace_id': e.get('workspaceId') or proj['workspace_id'],
+            'projectId': e.get('projectId'),
+            'taskId': e.get('taskId'),
+            'description': e.get('description'),
+            'start': e['timeInterval']['start'],
+            'billable': e.get('billable', True),
+        }
+        to_add[tag] = (user_data, entry)
+
+    to_remove = [
+        tag
+        for tag, session in active_sessions.items()
+        if (session.get('entry') or {}).get('clockify_entry_id') not in live_entry_ids
+    ]
+
+    return to_add, to_remove

--- a/Modules/time_checker.py
+++ b/Modules/time_checker.py
@@ -7,6 +7,7 @@ import requests
 
 from config import TIMEZONE, WORK_END_HOUR, REQUEST_TIMEOUT
 from Modules.state_manager import StateManager
+from Modules.reconcile import reconcile_sessions
 import Modules.logger as logger
 import Modules.display as display
 
@@ -82,12 +83,38 @@ class TimeChecker:
                 logging.error(f"Error ending overtime session: {e}")
 
     def check_startup_sessions(self):
-        """Log any sessions left active from a previous run."""
+        """Reconcile local sessions with Clockify (the source of truth).
+
+        Rebuilds any in-progress Clockify entry that has no local session
+        (e.g. a crash between starting the entry and saving local state, or a
+        timer that was running across a service restart), and drops local
+        sessions whose entry is no longer running.
+        """
         try:
-            sessions = self.state_manager.get_active_sessions()
-            for session in sessions.values():
-                user_name = session['user_data'].get('name', 'Unknown')
-                start_time = session['start_time']
-                logging.info(f"Found active session for {user_name} started at {start_time}")
+            db = logger.logger_instance.db
+            projects = db.get_all_projects()
+            workspaces = {p['workspace_id'] for p in projects}
+
+            in_progress = []
+            for ws in workspaces:
+                in_progress.extend(logger.logger_instance.get_in_progress(ws))
+
+            active = self.state_manager.get_active_sessions()
+            to_add, to_remove = reconcile_sessions(projects, in_progress, active)
+
+            for tag_uuid, (user_data, entry) in to_add.items():
+                self.state_manager.start_session(tag_uuid, user_data, entry)
+                logging.info(
+                    f"Recovered active session for {user_data['name']} "
+                    f"(Clockify entry {entry['clockify_entry_id']})"
+                )
+
+            for tag_uuid in to_remove:
+                name = active.get(tag_uuid, {}).get('user_data', {}).get('name', 'Unknown')
+                self.state_manager.end_session(tag_uuid)
+                logging.info(f"Cleared stale local session for {name} (entry not running)")
+
+            if not to_add and not to_remove:
+                logging.info(f"Startup reconcile: {len(active)} active session(s), all consistent")
         except Exception as e:
-            logging.error(f"Error checking startup session: {e}")
+            logging.error(f"Error reconciling startup sessions: {e}")

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,85 @@
+"""Unit tests for the pure reconciliation logic.
+
+Run from the repo root:
+    python3 -m unittest discover -s tests
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Modules.reconcile import reconcile_sessions
+
+
+PROJECTS = [
+    {'tag_uuid': 'tagA', 'name': 'Alice', 'user_id': 'u', 'project_id': 'projA',
+     'workspace_id': 'ws', 'task_id': 'tA'},
+    {'tag_uuid': 'tagB', 'name': 'Bob', 'user_id': 'u', 'project_id': 'projB',
+     'workspace_id': 'ws', 'task_id': 'tB'},
+]
+
+
+def entry(eid, project_id):
+    return {
+        'id': eid,
+        'projectId': project_id,
+        'taskId': 'tX',
+        'workspaceId': 'ws',
+        'description': 'desc',
+        'billable': True,
+        'timeInterval': {'start': '2026-06-09T08:00:00Z'},
+    }
+
+
+def session_for(eid):
+    return {'entry': {'clockify_entry_id': eid}}
+
+
+class ReconcileTest(unittest.TestCase):
+    def test_recovers_orphan_entry(self):
+        # Clockify has projA running, local has nothing -> recover tagA.
+        to_add, to_remove = reconcile_sessions(PROJECTS, [entry('e1', 'projA')], {})
+        self.assertIn('tagA', to_add)
+        user_data, e = to_add['tagA']
+        self.assertEqual(user_data['name'], 'Alice')
+        self.assertEqual(e['clockify_entry_id'], 'e1')
+        self.assertEqual(e['start'], '2026-06-09T08:00:00Z')
+        self.assertEqual(to_remove, [])
+
+    def test_skips_already_tracked(self):
+        # tagA already tracked locally for the same running entry -> no action.
+        active = {'tagA': session_for('e1')}
+        to_add, to_remove = reconcile_sessions(PROJECTS, [entry('e1', 'projA')], active)
+        self.assertEqual(to_add, {})
+        self.assertEqual(to_remove, [])
+
+    def test_removes_stale_session(self):
+        # Local thinks tagB is active but nothing is running in Clockify.
+        active = {'tagB': session_for('gone')}
+        to_add, to_remove = reconcile_sessions(PROJECTS, [], active)
+        self.assertEqual(to_add, {})
+        self.assertEqual(to_remove, ['tagB'])
+
+    def test_unmapped_project_ignored(self):
+        # Running entry for a project not in Supabase -> can't map, skip.
+        to_add, to_remove = reconcile_sessions(PROJECTS, [entry('e9', 'unknownProj')], {})
+        self.assertEqual(to_add, {})
+        self.assertEqual(to_remove, [])
+
+    def test_mixed_recover_and_remove(self):
+        # projA running (recover tagA); local tagB stale (remove).
+        active = {'tagB': session_for('old')}
+        to_add, to_remove = reconcile_sessions(PROJECTS, [entry('e1', 'projA')], active)
+        self.assertEqual(set(to_add), {'tagA'})
+        self.assertEqual(to_remove, ['tagB'])
+
+    def test_entry_workspace_fallback(self):
+        e = entry('e1', 'projA')
+        del e['workspaceId']
+        to_add, _ = reconcile_sessions(PROJECTS, [e], {})
+        self.assertEqual(to_add['tagA'][1]['workspace_id'], 'ws')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Makes the device resilient to crashes and restarts by treating Clockify as the source of truth for who is clocked in.

On startup (`check_startup_sessions`):
- **Recover orphans / surviving timers** — for each Clockify in-progress entry with no local session, rebuild it by mapping `projectId` → Supabase project row → `tag_uuid`. Fixes the crash-between-start-and-save gap, and means deploy restarts no longer strand active timers.
- **Drop stale sessions** — local sessions whose Clockify entry is no longer running are cleared, keeping the 8pm sweep and device display consistent.

## Design
- Logic extracted to a pure, hardware/config-free `Modules/reconcile.py` (`reconcile_sessions(projects, in_progress_entries, active_sessions) -> (to_add, to_remove)`), unit-tested in isolation.
- Wiring: `db_manager.get_all_projects()`, `ClockifyLogger.get_in_progress(ws)`, `time_checker.check_startup_sessions()`.
- All entries run under one Clockify API-key user keyed by project, so `projectId` → tag mapping is deterministic.

## Testing
- `tests/test_reconcile.py` — 6 cases (recover, skip-tracked, remove-stale, unmapped-skip, mixed, workspace fallback).
- Full suite **13/13 green on the Pi (Python 3.7)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)