### PR TITLE
Periodic reconcile + fetch-failure safety

### DIFF
--- a/Modules/logger.py
+++ b/Modules/logger.py
@@ -75,17 +75,22 @@ class ClockifyLogger:
         return response
 
     def get_in_progress(self, workspace_id):
-        """Return Clockify's currently in-progress entries for a workspace."""
+        """Clockify's in-progress entries for a workspace.
+
+        Returns a list on success (possibly empty), or None if the fetch
+        failed. Callers must distinguish: an empty list means "nothing
+        running", None means "don't trust this — leave local state alone".
+        """
         url = f'https://api.clockify.me/api/v1/workspaces/{workspace_id}/time-entries/status/in-progress'
         try:
             resp = requests.get(url, headers=self.headers, timeout=REQUEST_TIMEOUT)
             if resp.status_code != 200:
                 logging.error(f"Failed to fetch in-progress entries: {resp.text}")
-                return []
+                return None
             return resp.json() or []
         except Exception as e:
             logging.error(f"Error fetching in-progress entries: {e}")
-            return []
+            return None
 
     def endEntry(self, tag_uuid, time):
         """End the exact Clockify entry that this tag's session started.

--- a/Modules/time_checker.py
+++ b/Modules/time_checker.py
@@ -43,10 +43,13 @@ class TimeChecker:
         """Main checker loop"""
         while not self._stop_event.is_set():
             try:
+                # Re-sync with Clockify each tick so mid-day drift self-heals
+                # without waiting for a restart.
+                self.reconcile()
                 self._check_active_sessions()
             except Exception as e:
                 logging.error(f"Error in time checker: {e}")
-            
+
             # Sleep until next check, but allow interruption
             self._stop_event.wait(self.check_interval)
                 
@@ -82,22 +85,34 @@ class TimeChecker:
             except Exception as e:
                 logging.error(f"Error ending overtime session: {e}")
 
-    def check_startup_sessions(self):
+    def reconcile(self):
         """Reconcile local sessions with Clockify (the source of truth).
 
         Rebuilds any in-progress Clockify entry that has no local session
         (e.g. a crash between starting the entry and saving local state, or a
-        timer that was running across a service restart), and drops local
-        sessions whose entry is no longer running.
+        timer running across a restart), and drops local sessions whose entry
+        is no longer running.
+
+        Safe to run repeatedly. Bails out without touching local state if
+        Supabase projects can't be loaded or any Clockify fetch fails, so a
+        transient network error can never wipe active sessions.
         """
         try:
             db = logger.logger_instance.db
             projects = db.get_all_projects()
+            if not projects:
+                logging.warning("Reconcile skipped: no projects loaded")
+                return
+
             workspaces = {p['workspace_id'] for p in projects}
 
             in_progress = []
             for ws in workspaces:
-                in_progress.extend(logger.logger_instance.get_in_progress(ws))
+                fetched = logger.logger_instance.get_in_progress(ws)
+                if fetched is None:
+                    logging.warning("Reconcile skipped: Clockify fetch failed")
+                    return
+                in_progress.extend(fetched)
 
             active = self.state_manager.get_active_sessions()
             to_add, to_remove = reconcile_sessions(projects, in_progress, active)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     
     # Start time checker and check for leftover sessions
     time_checker = TimeChecker(check_interval=300)
-    time_checker.check_startup_sessions() # Check for leftover sessions
+    time_checker.reconcile() # Sync local state with Clockify before the loop
     time_checker.start()
     
     try:


### PR DESCRIPTION
## Summary
Extends startup reconciliation to run continuously, with a safeguard against transient network errors.

- **Periodic reconcile** — `reconcile()` now runs every checker tick (300s), not only at startup, so drift between Clockify and local state self-heals mid-day.
- **Fetch-failure safety** — `get_in_progress()` returns `None` on failure (distinct from `[]` = nothing running). `reconcile()` bails out without modifying local state if Supabase projects can't be loaded or any Clockify fetch fails. Without this, one network blip during a periodic run would mark every local session stale and wipe active sessions.
- Renamed `check_startup_sessions` → `reconcile` (general-purpose).

## Testing
- Full suite **13/13 green on the Pi (Python 3.7)**.
- Reconcile path verified live at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)